### PR TITLE
Add FastAPI hello world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # codextest
-trying out codex
+
+This repository contains a minimal FastAPI "Hello World" example. Follow the steps below to set up a virtual environment, install dependencies and run the server locally.
+
+## Setup
+
+1. **Create a virtual environment** (Python 3.8+ recommended):
+
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+
+2. **Install dependencies**:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Run the server**:
+
+   ```bash
+   python -m app.main
+   ```
+
+4. **Open your browser** and navigate to `http://localhost:8000/`. You should see a mostly blank page with the text "hello world".
+
+## Files
+
+- `app/main.py` – FastAPI application entry point.
+- `requirements.txt` – Python dependencies.
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+app = FastAPI()
+
+@app.get("/", response_class=HTMLResponse)
+async def read_root():
+    return "<html><body>hello world</body></html>"
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- create `app` package with FastAPI server that returns hello world
- add basic `requirements.txt`
- update README with steps for installing into a virtual environment and running the server

## Testing
- `python -m app.main & sleep 3; kill $!`
- `curl -s http://localhost:8000/`


------
https://chatgpt.com/codex/tasks/task_e_6841cc39e264832b9faf7a0898c0236a