### PR TITLE
Implement basic FastAPI + Vue TODO app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codextest
 
-This repository contains a minimal FastAPI "Hello World" example. Follow the steps below to set up a virtual environment, install dependencies and run the server locally.
+This repository contains a minimal FastAPI + Vue.js TODO application. Follow the steps below to set up a virtual environment, install dependencies and run the server locally.
 
 ## Setup
 
@@ -23,7 +23,7 @@ This repository contains a minimal FastAPI "Hello World" example. Follow the ste
    python -m app.main
    ```
 
-4. **Open your browser** and navigate to `http://localhost:8000/`. You should see a mostly blank page with the text "hello world".
+4. **Open your browser** and navigate to `http://localhost:8000/`. You should see a simple TODO application where you can add, edit and delete notes.
 
 ## Files
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,114 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
 
 app = FastAPI()
 
-@app.get("/", response_class=HTMLResponse)
-async def read_root():
-    return "<html><body>hello world</body></html>"
 
-if __name__ == "__main__":
+class TodoIn(BaseModel):
+    title: str
+    body: str
+
+
+class Todo(TodoIn):
+    id: int
+
+
+todos: list[Todo] = []
+current_id = 0
+
+
+INDEX_HTML = """<!DOCTYPE html>
+<html>
+<head>
+  <title>Todo App</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body>
+  <div id='app'>
+    <h1>Todos</h1>
+    <div>
+      <input v-model='newTitle' placeholder='Title' />
+      <input v-model='newBody' placeholder='Body' />
+      <button @click='addTodo'>Add Todo</button>
+    </div>
+    <div v-for='todo in todos' :key='todo.id' style='border:1px solid #ccc; margin:5px; padding:5px;'>
+      <input v-model='todo.title' @change='updateTodo(todo)' />
+      <textarea v-model='todo.body' @change='updateTodo(todo)'></textarea>
+      <button @click='deleteTodo(todo.id)'>Delete</button>
+    </div>
+  </div>
+  <script>
+    const { createApp } = Vue;
+    createApp({
+      data() {
+        return { todos: [], newTitle: '', newBody: '' };
+      },
+      methods: {
+        fetchTodos() {
+          fetch('/api/todos').then(r => r.json()).then(data => { this.todos = data; });
+        },
+        addTodo() {
+          fetch('/api/todos', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ title: this.newTitle, body: this.newBody }) })
+            .then(r => r.json())
+            .then(todo => { this.todos.push(todo); this.newTitle = ''; this.newBody = ''; });
+        },
+        updateTodo(todo) {
+          fetch('/api/todos/' + todo.id, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ title: todo.title, body: todo.body }) });
+        },
+        deleteTodo(id) {
+          fetch('/api/todos/' + id, { method: 'DELETE' }).then(r => { if (r.ok) { this.todos = this.todos.filter(t => t.id !== id); } });
+        }
+      },
+      mounted() {
+        this.fetchTodos();
+      }
+    }).mount('#app');
+  </script>
+</body>
+</html>"""
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    return INDEX_HTML
+
+
+@app.get("/api/todos", response_model=list[Todo])
+async def get_todos():
+    return todos
+
+
+@app.post("/api/todos", response_model=Todo)
+async def create_todo(todo: TodoIn):
+    global current_id
+    current_id += 1
+    item = Todo(id=current_id, **todo.dict())
+    todos.append(item)
+    return item
+
+
+@app.put("/api/todos/{todo_id}", response_model=Todo)
+async def update_todo(todo_id: int, todo: TodoIn):
+    for idx, item in enumerate(todos):
+        if item.id == todo_id:
+            updated = Todo(id=todo_id, **todo.dict())
+            todos[idx] = updated
+            return updated
+    raise HTTPException(status_code=404, detail='Todo not found')
+
+
+@app.delete("/api/todos/{todo_id}", status_code=204)
+async def delete_todo(todo_id: int):
+    for idx, item in enumerate(todos):
+        if item.id == todo_id:
+            todos.pop(idx)
+            return
+    raise HTTPException(status_code=404, detail='Todo not found')
+
+
+if __name__ == '__main__':
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host='0.0.0.0', port=8000)
+


### PR DESCRIPTION
## Summary
- convert example into an in-memory TODO app
- add minimal Vue.js UI served from FastAPI
- update README instructions

## Testing
- `python -m app.main`

------
https://chatgpt.com/codex/tasks/task_e_6841ce253f84832bbe7bd0ce16f0eae1